### PR TITLE
Update flow-remove-types

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "strip"
   ],
   "dependencies": {
-    "flow-remove-types": "^1.1.0",
+    "flow-remove-types": "^2.119.1",
     "rollup-pluginutils": "^1.5.1"
   },
   "devDependencies": {

--- a/test/expected.js
+++ b/test/expected.js
@@ -6,6 +6,9 @@ var someModule = require('some-module');
 
 /*       */
 
+const myClass                                       =
+  options => new MyClass(options.value);
+
 class MyClass    extends someModule.SomeClass                          {
 
           
@@ -20,4 +23,5 @@ class MyClass    extends someModule.SomeClass                          {
 
 }
 
+exports.myClass = myClass;
 exports.MyClass = MyClass;

--- a/test/source.js
+++ b/test/source.js
@@ -3,6 +3,9 @@
 import { SomeClass } from 'some-module'
 import type { SomeInterface } from 'some-module'
 
+export const myClass: <T>({ value: T, ... }) => MyClass<T> =
+  options => new MyClass(options.value)
+
 export class MyClass<T> extends SomeClass implements SomeInterface {
 
   value: T


### PR DESCRIPTION
`rollup-plugin-flow` fails on some new flow syntax.  Specifically, it fails on explicit inexact object type syntax (ellipsis in property definitions).  Updating to a more recent version of `flow-remove-types` fixes the issue.

Note: `flow-remove-types` version **2.120.1** fails on basic class syntax.  Seems like that version is not ready for production, yet.  Version **2.119.1** works on the updated tests and on our source code.
